### PR TITLE
The 2 deprecated beta endpoints have been disabled since April 1, 2019. 

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -102,13 +102,12 @@ print('\n-----------------------------------------------------------------------
 """
 print('***** search for business best match *****\n{}\n'.format("yelp_api.business_match_query(name='Splash Cafe', "
                                                                 "address1='197 Pomeroy Ave', ",
-                                                                "city='Pismo Beach', state='CA', country='US', match_type='lookup')"))
+                                                                "city='Pismo Beach', state='CA', country='US')"))
 response = yelp_api.business_match_query(name='Splash Cafe',
                                          address1='197 Pomeroy Ave',
                                          city='Pismo Beach',
                                          state='CA',
-                                         country='US',
-                                         match_type='lookup')
+                                         country='US')
 pprint(response)
 print('\n-------------------------------------------------------------------------\n')
 

--- a/yelpapi/yelpapi.py
+++ b/yelpapi/yelpapi.py
@@ -128,6 +128,7 @@ class YelpAPI(object):
                 * city
                 * state
                 * country
+                * address1
 
             match_type is deprecated since april 1, 2019.
         """
@@ -142,6 +143,9 @@ class YelpAPI(object):
 
         if not kwargs.get('country'):
             raise ValueError('Valid country (parameter "country") must be provided.')
+
+        if not kwargs.get('address1'):
+            raise ValueError('Valid address (parameter "address1") must be provided.')
 
         return self._query(BUSINESS_MATCH_API_URL, **kwargs)
 

--- a/yelpapi/yelpapi.py
+++ b/yelpapi/yelpapi.py
@@ -25,7 +25,7 @@ import requests
 
 AUTOCOMPLETE_API_URL = 'https://api.yelp.com/v3/autocomplete'
 BUSINESS_API_URL = 'https://api.yelp.com/v3/businesses/{}'
-BUSINESS_MATCH_API_URL = 'https://api.yelp.com/v3/businesses/matches/{}'
+BUSINESS_MATCH_API_URL = 'https://api.yelp.com/v3/businesses/matches'
 EVENT_LOOKUP_API_URL = 'https://api.yelp.com/v3/events/{}'
 EVENT_SEARCH_API_URL = 'https://api.yelp.com/v3/events'
 FEATURED_EVENT_API_URL = 'https://api.yelp.com/v3/events/featured'
@@ -117,7 +117,7 @@ class YelpAPI(object):
 
         return self._query(BUSINESS_API_URL.format(id), **kwargs)
 
-    def business_match_query(self, match_type='best', **kwargs):
+    def business_match_query(self, **kwargs):
         """
             Query the Yelp Business Match API.
             
@@ -128,6 +128,8 @@ class YelpAPI(object):
                 * city
                 * state
                 * country
+
+            match_type is deprecated since april 1, 2019.
         """
         if not kwargs.get('name'):
             raise ValueError('Valid business name (parameter "name") must be provided.')
@@ -141,11 +143,7 @@ class YelpAPI(object):
         if not kwargs.get('country'):
             raise ValueError('Valid country (parameter "country") must be provided.')
 
-        if match_type not in {'best', 'lookup'}:
-            raise ValueError('Valid match type (parameter "match_type") must be provided. Accepted values: "best" or '
-                             '"lookup".')
-
-        return self._query(BUSINESS_MATCH_API_URL.format(match_type), **kwargs)
+        return self._query(BUSINESS_MATCH_API_URL, **kwargs)
 
     def event_lookup_query(self, id, **kwargs):
         """


### PR DESCRIPTION
From the doc https://www.yelp.com/developers/documentation/v3/business_match

Also added a missing required parameter in the _doc_. 